### PR TITLE
[NeoForge 1.21.1] Fix crashes on dedicated servers

### DIFF
--- a/src/main/java/net/tejty/gamediscs/GameDiscsMod.java
+++ b/src/main/java/net/tejty/gamediscs/GameDiscsMod.java
@@ -27,24 +27,5 @@ public class GameDiscsMod {
         LootModifiers.register(eventBus);
         SoundRegistry.register(eventBus);
         DataComponentRegistry.register(eventBus);
-
-        eventBus.addListener(this::commonSetup);
-        NeoForge.EVENT_BUS.register(this);
-    }
-
-    private void commonSetup(final FMLCommonSetupEvent event) {
-
-    }
-
-    @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-
-    }
-
-    @EventBusSubscriber(modid = MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-    public static class ClientModEvents { @SubscribeEvent
-        public static void onClientSetup(FMLClientSetupEvent event) {
-
-        }
     }
 }

--- a/src/main/java/net/tejty/gamediscs/client/ClientUtils.java
+++ b/src/main/java/net/tejty/gamediscs/client/ClientUtils.java
@@ -1,0 +1,46 @@
+package net.tejty.gamediscs.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.tejty.gamediscs.client.screen.GamingConsoleScreen;
+import net.tejty.gamediscs.games.gamediscs.*;
+import net.tejty.gamediscs.games.util.Game;
+import net.tejty.gamediscs.item.ItemRegistry;
+import net.tejty.gamediscs.item.custom.GameDiscItem;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ClientUtils {
+    public static void openConsoleScreen() {
+        Minecraft.getInstance().setScreen(new GamingConsoleScreen(Component.translatable("gui.gamingconsole.title")));
+    }
+
+    private static final Map<Item, Supplier<Game>> GAMES = new IdentityHashMap<>();
+
+    private static void registerGames() {
+        GAMES.put(ItemRegistry.GAME_DISC_FLAPPY_BIRD.get(), FlappyBirdGame::new);
+        GAMES.put(ItemRegistry.GAME_DISC_SLIME.get(), SlimeGame::new);
+        GAMES.put(ItemRegistry.GAME_DISC_BLOCKTRIS.get(), BlocktrisGame::new);
+        GAMES.put(ItemRegistry.GAME_DISC_TNT_SWEEPER.get(), TntSweeperGame::new);
+        GAMES.put(ItemRegistry.GAME_DISC_PONG.get(), PongGame::new);
+        GAMES.put(ItemRegistry.GAME_DISC_FROGGIE.get(), FroggieGame::new);
+        // TODO
+        //GAMES.put(ItemRegistry.GAME_DISC_RABBIT.get(), RabbitGame::new);
+    }
+
+    public static Game newGameFor(GameDiscItem item) {
+        if (GAMES.isEmpty()) {
+            registerGames();
+        }
+
+        Supplier<Game> sup = GAMES.get(item);
+        if (sup == null) {
+            throw new IllegalArgumentException("No game specified for " + item + " (" + BuiltInRegistries.ITEM.getKey(item) + ")");
+        }
+        return sup.get();
+    }
+}

--- a/src/main/java/net/tejty/gamediscs/client/screen/GamingConsoleScreen.java
+++ b/src/main/java/net/tejty/gamediscs/client/screen/GamingConsoleScreen.java
@@ -14,7 +14,6 @@ import net.tejty.gamediscs.games.util.Game;
 import net.tejty.gamediscs.item.custom.GameDiscItem;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -69,16 +68,14 @@ public class GamingConsoleScreen extends Screen {
 
         // Scans for games in player's inventory
         availableGames = scanForGames();
+    }
 
-        // Creates timer that calls tick() in Game every 50ms (20 times per second)
-        Timer timer = new Timer(50, e -> {
-            if (game != null) {
-                game.tick();
-            }
-        });
-
-        // Starts the timer
-        timer.start();
+    @Override
+    public void tick() {
+        // Calls tick() in Game every 50ms (20 times per second)
+        if (game != null) {
+            game.tick();
+        }
     }
 
     // This screen doesn't pause the game when opened

--- a/src/main/java/net/tejty/gamediscs/client/screen/GamingConsoleScreen.java
+++ b/src/main/java/net/tejty/gamediscs/client/screen/GamingConsoleScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.tejty.gamediscs.GameDiscsMod;
+import net.tejty.gamediscs.client.ClientUtils;
 import net.tejty.gamediscs.games.controls.Button;
 import net.tejty.gamediscs.games.util.Game;
 import net.tejty.gamediscs.item.custom.GameDiscItem;
@@ -15,7 +16,9 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class GamingConsoleScreen extends Screen {
@@ -191,18 +194,17 @@ public class GamingConsoleScreen extends Screen {
      */
     public List<Game> scanForGames() {
         // Creating the list of the games
-        List<Game> games = new ArrayList<>();
-        Player player = Minecraft.getInstance().player;
+        Map<GameDiscItem, Game> games = new IdentityHashMap<>();
+        Player player = Objects.requireNonNull(Minecraft.getInstance().player);
 
         // Going through each slot of player's inventory
-        for (int i = 0; i < Objects.requireNonNull(player).getInventory().getContainerSize(); i++) {
+        for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
             // If the item is GameDisc, it adds it to the list
             if (player.getInventory().getItem(i).getItem() instanceof GameDiscItem disc) {
-                games.removeIf((game) -> game.getClass().equals(disc.getGame().getClass()));
-                games.add(disc.getGame());
+                games.computeIfAbsent(disc, ClientUtils::newGameFor);
             }
         }
-        return games;
+        return new ArrayList<>(games.values());
     }
 
     // Main method for pressed keys

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/BlocktrisGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/BlocktrisGame.java
@@ -45,7 +45,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         super.prepare();
 
         grid = new Grid(
@@ -68,7 +68,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         super.start();
         for (int i = 0; i < 3; i++) {
             int type = random.nextInt(0, 7);
@@ -86,7 +86,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         if (piece.move(0, 1)) {
             placePiece();
         }
@@ -98,7 +98,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         super.render(graphics, posX, posY);
 
         grid.render(graphics, posX + 45, posY - 15);
@@ -129,7 +129,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         super.buttonDown(button);
         if (stage == GameStage.PLAYING && ticks > 5) {
             if (button == Button.UP) {
@@ -179,7 +179,7 @@ public class BlocktrisGame extends Game {
     }
 
     @Override
-    public synchronized void tick() {
+    public void tick() {
         super.tick();
         if (stage == GameStage.PLAYING && ticks % 2 == 0) {
             if (controls.isButtonDown(Button.LEFT) && controls.wasButtonDown(Button.LEFT)) {

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/ExampleGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/ExampleGame.java
@@ -15,7 +15,7 @@ public class ExampleGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -24,7 +24,7 @@ public class ExampleGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -32,7 +32,7 @@ public class ExampleGame extends Game {
         // here
     }
     @Override
-    public synchronized void tick() {
+    public void tick() {
         // Calls tick of super
         super.tick();
 
@@ -40,7 +40,7 @@ public class ExampleGame extends Game {
         // here
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -50,7 +50,7 @@ public class ExampleGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         // Calling die of super
         super.die();
 
@@ -60,7 +60,7 @@ public class ExampleGame extends Game {
     }
 
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -75,7 +75,7 @@ public class ExampleGame extends Game {
         renderOverlay(graphics, posX, posY);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls buttonDown of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/FlappyBirdGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/FlappyBirdGame.java
@@ -35,7 +35,7 @@ public class FlappyBirdGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -51,7 +51,7 @@ public class FlappyBirdGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -59,7 +59,7 @@ public class FlappyBirdGame extends Game {
         pipeSpawnTimer = 0;
     }
     @Override
-    public synchronized void tick() {
+    public void tick() {
         // Calls tick of super
         super.tick();
 
@@ -77,7 +77,7 @@ public class FlappyBirdGame extends Game {
         }
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -145,7 +145,7 @@ public class FlappyBirdGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         super.die();
         bird.hide();
         spawnParticleExplosion(
@@ -175,7 +175,7 @@ public class FlappyBirdGame extends Game {
         pipes.getLast().setVelocity(new Vec2(-2.5f, 0f));
     }
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -199,7 +199,7 @@ public class FlappyBirdGame extends Game {
         renderOverlay(graphics, posX, posY);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls buttonDown of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/FroggieGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/FroggieGame.java
@@ -63,7 +63,7 @@ public class FroggieGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         isHoleFull = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             isHoleFull.add(false);
@@ -320,7 +320,7 @@ public class FroggieGame extends Game {
     }
 
     @Override
-    public synchronized void respawn() {
+    public void respawn() {
         super.respawn();
 
         frog.setPos(new Vec2((float) WIDTH / 2 - (float) TILE_SIZE / 2, 13 * TILE_SIZE));
@@ -333,7 +333,7 @@ public class FroggieGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
 
         // Calls start of super
         super.start();
@@ -342,7 +342,7 @@ public class FroggieGame extends Game {
         // here
     }
     @Override
-    public synchronized void tick() {
+    public void tick() {
         // Calls tick of super
         super.tick();
 
@@ -350,7 +350,7 @@ public class FroggieGame extends Game {
         // here
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -476,7 +476,7 @@ public class FroggieGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         // Calling die of super
         super.die();
 
@@ -491,7 +491,7 @@ public class FroggieGame extends Game {
     }
 
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -535,7 +535,7 @@ public class FroggieGame extends Game {
         renderOverlay(graphics, posX, posY);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls buttonDown of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/PongGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/PongGame.java
@@ -48,7 +48,7 @@ public class PongGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -80,7 +80,7 @@ public class PongGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -88,7 +88,7 @@ public class PongGame extends Game {
         ballTimer = 60;
     }
     @Override
-    public synchronized void tick() {
+    public void tick() {
         // Calls tick of super
         super.tick();
 
@@ -98,7 +98,7 @@ public class PongGame extends Game {
         }
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -161,7 +161,7 @@ public class PongGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         // Calling die of super
         super.die();
 
@@ -171,7 +171,7 @@ public class PongGame extends Game {
     }
 
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -229,7 +229,7 @@ public class PongGame extends Game {
         renderOverlay(graphics, posX, posY);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls buttonDown of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/RabbitGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/RabbitGame.java
@@ -38,7 +38,7 @@ public class RabbitGame extends Game {
     }
 
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -55,7 +55,7 @@ public class RabbitGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -63,7 +63,7 @@ public class RabbitGame extends Game {
         cactusSpawnTimer = 0;
     }
     @Override
-    public synchronized void tick() {
+    public void tick() {
         // Calls tick of super
         super.tick();
 
@@ -81,7 +81,7 @@ public class RabbitGame extends Game {
         }
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -138,7 +138,7 @@ public class RabbitGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         super.die();
         rabbit.hide();
         spawnParticleExplosion(
@@ -159,7 +159,7 @@ public class RabbitGame extends Game {
         cactus.get(cactus.size() - 1).setVelocity(new Vec2(speed, 0f));
     }
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -183,7 +183,7 @@ public class RabbitGame extends Game {
         renderOverlay(graphics, posX, posY);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls buttonDown of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/SlimeGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/SlimeGame.java
@@ -59,7 +59,7 @@ public class SlimeGame extends Game {
         super();
     }
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -73,7 +73,7 @@ public class SlimeGame extends Game {
         respawnApple();
     }
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -81,7 +81,7 @@ public class SlimeGame extends Game {
         direction = VecUtil.VEC_RIGHT;
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
 
@@ -128,7 +128,7 @@ public class SlimeGame extends Game {
         addParticle(new Particle(calcPos(slime.getFirst().add(VecUtil.randomFloat(Vec2.ZERO, new Vec2(1, 1), random))), new BreakParticleRenderer(BODY, 8, 8), random.nextInt(20, 50), ParticleLevel.RUNNING_GAME));
     }
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -219,7 +219,7 @@ public class SlimeGame extends Game {
         return tile.scale(TILE_SIZE).add(GAME_POS);
     }
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         // Calls button down of super
         super.buttonDown(button);
 

--- a/src/main/java/net/tejty/gamediscs/games/gamediscs/TntSweeperGame.java
+++ b/src/main/java/net/tejty/gamediscs/games/gamediscs/TntSweeperGame.java
@@ -87,7 +87,7 @@ public class TntSweeperGame extends Game {
         super();
     }
     @Override
-    public synchronized void prepare() {
+    public void prepare() {
         // Calls prepare of super
         super.prepare();
 
@@ -97,7 +97,7 @@ public class TntSweeperGame extends Game {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         // Calls start of super
         super.start();
 
@@ -116,13 +116,13 @@ public class TntSweeperGame extends Game {
         }
     }
     @Override
-    public synchronized void gameTick() {
+    public void gameTick() {
         // Calls game tick of super
         super.gameTick();
     }
 
     @Override
-    public synchronized void tick() {
+    public void tick() {
         super.tick();
 
         if ((stage == GameStage.PLAYING || stage == GameStage.START) && ticks % 2 == 0) {
@@ -144,7 +144,7 @@ public class TntSweeperGame extends Game {
     }
 
     @Override
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Calls render of super
         super.render(graphics, posX, posY);
 
@@ -187,7 +187,7 @@ public class TntSweeperGame extends Game {
     }
 
     @Override
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         soundPlayer.playClick(true);
 
         // Prepares the game
@@ -263,7 +263,7 @@ public class TntSweeperGame extends Game {
     }
 
     @Override
-    public synchronized void die() {
+    public void die() {
         super.die();
 
         for (Vec2 bomb : bombs) {

--- a/src/main/java/net/tejty/gamediscs/games/util/Game.java
+++ b/src/main/java/net/tejty/gamediscs/games/util/Game.java
@@ -61,7 +61,7 @@ public class Game {
      * Resets all variables and prepares for start
      */
     
-    public synchronized void prepare() {
+    public void prepare() {
         score = 0;
         lives = maxLives();
         respawn();
@@ -71,7 +71,7 @@ public class Game {
      * Starts the game
      */
     
-    public synchronized void start() {
+    public void start() {
         stage = GameStage.PLAYING;
         ticks = 1;
     }
@@ -80,7 +80,7 @@ public class Game {
      * Stops the game, shows die screen, and sets the best score
      */
     
-    public synchronized void die() {
+    public void die() {
         if (getConsole().getItem() instanceof GamingConsoleItem) {
             // Tries to set the best score
             String gameName = this.getClass().getName().substring(this.getClass().getPackageName().length() + 1);
@@ -98,7 +98,7 @@ public class Game {
         ticks = 1;
     }
 
-    public synchronized void lostLife() {
+    public void lostLife() {
         lives--;
         soundPlayer.play(SoundRegistry.EXPLOSION.get());
         respawn();
@@ -107,7 +107,7 @@ public class Game {
         }
     }
 
-    public synchronized void respawn() {
+    public void respawn() {
         stage = GameStage.START;
         ticks = 1;
         particles.clear();
@@ -117,7 +117,7 @@ public class Game {
      * Stops the game, shows win screen, and sets the best score
      */
     
-    public synchronized void win() {
+    public void win() {
         soundPlayer.playNewBest();
         spawnConfetti();
         if (getConsole().getItem() instanceof GamingConsoleItem) {
@@ -161,7 +161,7 @@ public class Game {
      * Updates everything by one tick
      */
     
-    public synchronized void tick() {
+    public void tick() {
         // Calls gameTick depending on game stage and game tick duration
         if (stage == GameStage.PLAYING && ticks % gameTickDuration() == 0) {
             gameTick();
@@ -185,7 +185,7 @@ public class Game {
      * Updates everything in game by one tick
      */
     
-    public synchronized void gameTick() {
+    public void gameTick() {
     }
 
     /**
@@ -195,7 +195,7 @@ public class Game {
      * @param posY Y position of the game area
      */
     
-    public synchronized void render(GuiGraphics graphics, int posX, int posY) {
+    public void render(GuiGraphics graphics, int posX, int posY) {
         // Renders background
         if (getBackground() != null) {
             graphics.blit(getBackground(), posX, posY, 0, 0, 0, WIDTH, HEIGHT, WIDTH, HEIGHT);
@@ -211,7 +211,7 @@ public class Game {
      * @param posY Y position
      */
     
-    public synchronized void renderOverlay(GuiGraphics graphics, int posX, int posY) {
+    public void renderOverlay(GuiGraphics graphics, int posX, int posY) {
         // saving font
         Font font = Minecraft.getInstance().font;
 
@@ -350,7 +350,7 @@ public class Game {
     }
 
     
-    public synchronized void renderParticles(GuiGraphics graphics, int posX, int posY) {
+    public void renderParticles(GuiGraphics graphics, int posX, int posY) {
         for (Particle particle : particles) {
             particle.render(graphics, posX, posY, stage);
         }
@@ -361,7 +361,7 @@ public class Game {
      * @param button The button that was pressed
      */
     
-    public synchronized void buttonDown(Button button) {
+    public void buttonDown(Button button) {
         soundPlayer.playClick(true);
         // Starts the game
         if ((stage == GameStage.START || stage == GameStage.RETRY) && ticks > 8) {
@@ -411,7 +411,7 @@ public class Game {
      * @param button The button that was released
      */
     
-    public synchronized void buttonUp(Button button) {
+    public void buttonUp(Button button) {
         soundPlayer.playClick(false);
     }
 

--- a/src/main/java/net/tejty/gamediscs/item/ItemRegistry.java
+++ b/src/main/java/net/tejty/gamediscs/item/ItemRegistry.java
@@ -8,7 +8,6 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.tejty.gamediscs.GameDiscsMod;
-import net.tejty.gamediscs.games.gamediscs.*;
 import net.tejty.gamediscs.item.custom.GameDiscItem;
 import net.tejty.gamediscs.item.custom.GamingConsoleItem;
 
@@ -18,19 +17,19 @@ public class ItemRegistry {
     public static final DeferredItem<Item> GAMING_CONSOLE = ITEMS.register("gaming_console",
             () -> new GamingConsoleItem(new Item.Properties().rarity(Rarity.UNCOMMON)));
     public static final DeferredItem<Item> GAME_DISC_FLAPPY_BIRD = ITEMS.register("game_disc_flappy_bird",
-            () -> new GameDiscItem(new Item.Properties().rarity(Rarity.RARE), FlappyBirdGame::new, Component.translatable("gamediscs.flappy_bird").withStyle(ChatFormatting.YELLOW)));
+            () -> new GameDiscItem(new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.flappy_bird").withStyle(ChatFormatting.YELLOW)));
     public static final DeferredItem<Item> GAME_DISC_SLIME = ITEMS.register("game_disc_slime", () -> new GameDiscItem(
-                    new Item.Properties().rarity(Rarity.RARE), SlimeGame::new, Component.translatable("gamediscs.slime").withStyle(ChatFormatting.DARK_GREEN)));
+                    new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.slime").withStyle(ChatFormatting.DARK_GREEN)));
     public static final DeferredItem<Item> GAME_DISC_BLOCKTRIS = ITEMS.register("game_disc_blocktris", () -> new GameDiscItem(
-                    new Item.Properties().rarity(Rarity.RARE), BlocktrisGame::new, Component.translatable("gamediscs.blocktris").withStyle(ChatFormatting.BLUE)));
+                    new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.blocktris").withStyle(ChatFormatting.BLUE)));
     public static final DeferredItem<Item> GAME_DISC_TNT_SWEEPER = ITEMS.register("game_disc_tnt_sweeper", () -> new GameDiscItem(
-                    new Item.Properties().rarity(Rarity.RARE), TntSweeperGame::new, Component.translatable("gamediscs.tnt_sweeper").withStyle(ChatFormatting.RED)));
+                    new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.tnt_sweeper").withStyle(ChatFormatting.RED)));
     public static final DeferredItem<Item> GAME_DISC_PONG = ITEMS.register("game_disc_pong", () -> new GameDiscItem(
-                    new Item.Properties().rarity(Rarity.RARE), PongGame::new, Component.translatable("gamediscs.pong_game").withStyle(ChatFormatting.WHITE)));
+                    new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.pong_game").withStyle(ChatFormatting.WHITE)));
     public static final DeferredItem<Item> GAME_DISC_FROGGIE = ITEMS.register("game_disc_froggie", () -> new GameDiscItem(
-                    new Item.Properties().rarity(Rarity.RARE), FroggieGame::new, Component.translatable("gamediscs.froggie").withStyle(ChatFormatting.GREEN)));
+                    new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.froggie").withStyle(ChatFormatting.GREEN)));
     // public static final DeferredItem<Item> GAME_DISC_RABBIT = ITEMS.register("game_disc_rabbit", () -> new GameDiscItem(
-    //                new Item.Properties().rarity(Rarity.RARE), RabbitGame::new, Component.translatable("gamediscs.rabbit").withStyle(ChatFormatting.GOLD))); //TODO translation missing
+    //                new Item.Properties().rarity(Rarity.RARE), Component.translatable("gamediscs.rabbit").withStyle(ChatFormatting.GOLD))); //TODO translation missing
 
 
 

--- a/src/main/java/net/tejty/gamediscs/item/custom/GameDiscItem.java
+++ b/src/main/java/net/tejty/gamediscs/item/custom/GameDiscItem.java
@@ -8,21 +8,14 @@ import net.tejty.gamediscs.games.util.Game;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
-import java.util.function.Supplier;
 
 @ParametersAreNonnullByDefault
 public class GameDiscItem extends Item {
-    private final Supplier<Game> gameSupplier;
     private final Component name;
 
-    public GameDiscItem(Properties pProperties, Supplier<Game> gameSupplier, Component name) {
+    public GameDiscItem(Properties pProperties, Component name) {
         super(pProperties.stacksTo(1));
-        this.gameSupplier = gameSupplier;
         this.name = name;
-    }
-
-    public Game getGame() {
-        return gameSupplier.get();
     }
 
     @Override

--- a/src/main/java/net/tejty/gamediscs/item/custom/GamingConsoleItem.java
+++ b/src/main/java/net/tejty/gamediscs/item/custom/GamingConsoleItem.java
@@ -8,6 +8,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.tejty.gamediscs.client.ClientUtils;
 import net.tejty.gamediscs.client.screen.GamingConsoleScreen;
 import net.tejty.gamediscs.component.BestScoreComponent;
 import net.tejty.gamediscs.component.DataComponentRegistry;
@@ -25,8 +28,10 @@ public class GamingConsoleItem extends Item {
 
     @Override
     public @NotNull InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
-        if (level.isClientSide()) {
-            Minecraft.getInstance().setScreen(new GamingConsoleScreen(Component.translatable("gui.gamingconsole.title")));
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            if (level.isClientSide()) {
+                ClientUtils.openConsoleScreen();
+            }
         }
 
         return super.use(level, player, hand);


### PR DESCRIPTION
As the title suggests, this PR fixes the crashes that were occurring on dedicated servers. Furthermore, I've tested these changes and can verify that the mod works perfectly on dedicated servers — the games I tested (Slime and Flappy Bee) work fine and scores can be set etc. all without any errors on the server.

The primary change in this PR is the decoupling of the game instances from their disc items (see `ClientUtils`). That setup isn't ideal but it works. If many more games were to be added it might be a good idea to turn it into a full (client-side) `Registry` and have the game discs store a `ResourceLocation` identifying the corresponding game. (If you would like I can do that in this PR.)

This PR also includes another change which is unrelated but still useful I think. Specifically, it removes the use of Swing's `Timer` in favor of just using `Screen`.`tick()`, and also removes all the `synchronized` modifiers which may have had unintended side effects on say, the integrated server and any other unrelated `Thread`s.